### PR TITLE
Allow `expectError` assertions to detect `Expected at least arguments` error

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -23,6 +23,7 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.TypeDoesNotSatisfyTheConstraint,
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
 	DiagnosticCode.ExpectedArgumentsButGotOther,
+	DiagnosticCode.ExpectedAtLeastArgumentsButGotOther,
 	DiagnosticCode.NoOverloadExpectsCountOfArguments,
 	DiagnosticCode.NoOverloadExpectsCountOfTypeArguments,
 	DiagnosticCode.NoOverloadMatches,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -32,6 +32,7 @@ export enum DiagnosticCode {
 	ArgumentTypeIsNotAssignableToParameterType = 2345,
 	CannotAssignToReadOnlyProperty = 2540,
 	ExpectedArgumentsButGotOther = 2554,
+	ExpectedAtLeastArgumentsButGotOther = 2555,
 	TypeHasNoPropertiesInCommonWith = 2559,
 	ValueOfTypeNotCallable = 2348,
 	ExpressionNotCallable = 2349,

--- a/source/test/fixtures/expect-error/values/index.d.ts
+++ b/source/test/fixtures/expect-error/values/index.d.ts
@@ -13,6 +13,8 @@ export type HasKey<K extends string, V = unknown> = {[P in K]?: V};
 
 export function getFoo<T extends HasKey<'foo'>>(obj: T): T['foo'];
 
+export function atLeastOne(...expected: [unknown, ...Array<unknown>]): void;
+
 export interface Options<T> {}
 
 export class MyClass {}

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectError} from '../../../..';
-import {default as one, foo, getFoo, HasKey, hasProperty, MyClass, Options} from '.';
+import {default as one, atLeastOne, foo, getFoo, HasKey, hasProperty, MyClass, Options} from '.';
 
 expectError<string>(1);
 expectError<string>('fo');
@@ -20,6 +20,8 @@ expectError(hasProperty({name: 1}));
 expectError(one(1));
 expectError(one(1, 2, 3));
 expectError({} as Options);
+
+expectError(atLeastOne())
 
 expectError(getFoo({bar: 1} as HasKey<'bar'>));
 


### PR DESCRIPTION
Currently `expectError` does not silence "Expected at least {0} arguments, but got {1}. ts(2555)" error (similar 2554 is silenced). For example:

```ts
// declaration
export function atLeastOne(...expected: [unknown, ...Array<unknown>]): void;

//test
expectError(atLeastOne())
```

Will fail with:
```
✖  4:0   Expected an error, but found none.         
✖  4:21  Expected at least 1 arguments, but got 0.  
```

This PR is adding `2555` to the list of silence errors. With this patch, the test above will pass.
