### PR TITLE
Improve `files` pattern in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"files": [
 		"dist/**/*.js",
 		"dist/**/*.d.ts",
-		"!dist/test"
+		"!dist/test/**/*"
 	],
 	"keywords": [
 		"typescript",


### PR DESCRIPTION
At the moment the test files get published to `npm`. I noticed that by accident while messing up within `node_modules/tsd` directory. This can also be observed by running `npm publish --dry-run`.

All together these are 14 files or almost one third of the unpacked size of the library. Rather significant.

Seems like publishing these files was not intentional. Just wanted to draw your attention.