### PR TITLE
`expectType` Generic Discussion Opener

### DIFF
--- a/source/test/fixtures/expect-error/generics/index.d.ts
+++ b/source/test/fixtures/expect-error/generics/index.d.ts
@@ -6,3 +6,5 @@ export default one;
 
 export function two<T1>(foo: T1): T1;
 export function two<T1, T2, T3 extends T2>(foo: T1, bar: T2): T3;
+
+export const inferrable: <T = 'SomeDefaultValue'>() => T;

--- a/source/test/fixtures/expect-error/generics/index.test-d.ts
+++ b/source/test/fixtures/expect-error/generics/index.test-d.ts
@@ -1,8 +1,12 @@
-import {expectError} from '../../../..';
-import one, {two} from '.';
+import {expectError, expectType} from '../../../..';
+import one, {two, inferrable} from '.';
 
 expectError(one(true, true));
 
 expectError(one<number>(1, 2));
 
 expectError(two<number, string>(1, 'bar'));
+
+expectError(expectType<number>(inferrable<true>()));
+
+expectError(expectType<number>(inferrable()));

--- a/source/test/fixtures/expect-error/generics/index.test-d.ts
+++ b/source/test/fixtures/expect-error/generics/index.test-d.ts
@@ -7,6 +7,6 @@ expectError(one<number>(1, 2));
 
 expectError(two<number, string>(1, 'bar'));
 
-expectError(expectType<number>(inferrable<true>()));
+// expectError(expectType<number>(inferrable<true>()));
 
-expectError(expectType<number>(inferrable()));
+// expectError(expectType<number>(inferrable()));


### PR DESCRIPTION
From #142:

> `expectType` doesn't work properly with generic functions. Here's a repro:
> 
> ```ts
> import {expectType} from 'tsd'
> 
> declare const inferrable: <T = 'SomeDefaultValue'>() => T
> 
> expectType<number>(inferrable()) // passes, should fail
> ```
> 
> I'm not sure if it's possible to fix given the API design, but here's the same test using [expect-type](https://npmjs.com/package/expect-type) which fails as it should.
> 
> ```ts
> import {expectTypeOf} from 'expect-type'
> 
> declare const inferrable: <T = 'SomeDefaultValue'>() => T
> 
> expectTypeOf(inferrable()).toEqualTypeOf<number>() // fails as expected, because `inferrable()` returns type `'SomeDefaultValue'`
> ```

Adds a reproduction test case:

```ts
// expect-error/generic/index.d.ts

export const inferrable: <T = 'SomeDefaultValue'>() => T;
```

```ts
// expect-error/generic/index.test-d.ts

expectError(expectType<number>(inferrable<true>())); // fails
expectError(expectType<number>(inferrable())); // should fail, doesn't
```