### PR TITLE
Add code 2561 to known errors

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -44,6 +44,7 @@ const expectErrorDiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.MemberMustHaveOverrideModifier,
 	DiagnosticCode.StringLiteralTypeIsNotAssignableToUnionTypeWithSuggestion,
 	DiagnosticCode.ObjectLiteralMayOnlySpecifyKnownProperties,
+	DiagnosticCode.ObjectLiteralMayOnlySpecifyKnownProperties2,
 ]);
 
 type IgnoreDiagnosticResult = 'preserve' | 'ignore' | Location;

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -40,6 +40,7 @@ export enum DiagnosticCode {
 	OnlyVoidFunctionIsNewCallable = 2350,
 	ExpressionNotConstructable = 2351,
 	ObjectLiteralMayOnlySpecifyKnownProperties = 2353,
+	ObjectLiteralMayOnlySpecifyKnownProperties2 = 2561,
 	TypeNotAssignableWithExactOptionalPropertyTypes = 2375,
 	TypeNotAssignableToParameterWithExactOptionalPropertyTypes = 2379,
 	TypeNotAssignableTypeOfTargetWithExactOptionalPropertyTypes = 2412,


### PR DESCRIPTION
Followup to #202 and #204. After upgrading in https://github.com/Automattic/mongoose/pull/14221 to tsd@0.30, I started getting the following errors:

```
  test/types/base.test.ts:61:29
  ✖   61:2   Found an error that tsd does not currently support (ts2353), consider creating an issue on GitHub.                                                                                                                                                                                                                                                               
  ✖   61:29  Object literal may only specify known properties, and invalid does not exist in type { allowDiskUse?: boolean | undefined; applyPluginsToChildSchemas?: boolean | undefined; applyPluginsToDiscriminators?: boolean | undefined; autoCreate?: boolean | undefined; autoIndex?: boolean | undefined; ... 21 more ...; translateAliases?: boolean | undefined; }.  

  test/types/models.test.ts:350:10
  ✖  346:2   Found an error that tsd does not currently support (ts2561), consider creating an issue on GitHub.                                                                                                                                                                                                                                                               
  ✖  350:10  Object literal may only specify known properties, but test does not exist in type OptionalId<{ testy: string; }>. Did you mean to write testy?                                                                                                                                                                                                                   

  4 errors

```

Why is 2561 a separate diagnostic code from 2353 even though the error message only differs "and" -> "but"? No idea. But this seems to fix the issue. I'm also open to suggestions for a better name than `ObjectLiteralMayOnlySpecifyKnownProperties2`.