### PR TITLE
Add code 2740 to known errors

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -28,6 +28,7 @@ const expectErrorDiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.NoOverloadExpectsCountOfArguments,
 	DiagnosticCode.NoOverloadExpectsCountOfTypeArguments,
 	DiagnosticCode.NoOverloadMatches,
+	DiagnosticCode.Type1IsMissingPropertiesFromType2,
 	DiagnosticCode.PropertyMissingInType1ButRequiredInType2,
 	DiagnosticCode.TypeHasNoPropertiesInCommonWith,
 	DiagnosticCode.ThisContextOfTypeNotAssignableToMethodOfThisType,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -46,6 +46,7 @@ export enum DiagnosticCode {
 	IndexSignatureOnlyPermitsReading = 2542,
 	NoOverloadExpectsCountOfArguments = 2575,
 	ThisContextOfTypeNotAssignableToMethodOfThisType = 2684,
+	Type1IsMissingPropertiesFromType2 = 2740,
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 	NoOverloadExpectsCountOfTypeArguments = 2743,
 	NoOverloadMatches = 2769,


### PR DESCRIPTION
Immutable-js is moving towards using `tsd` on the next release and I encountered this error in one test case being migrated. 
https://github.com/arnfaldur/immutable-js/blob/a23550e48343b8ae902688856fd8b9f6ae1b15ec/type-definitions/ts-tests/map.ts#L275
