### PR TITLE
Add `ts2739` to known errors

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -28,7 +28,7 @@ const expectErrorDiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.NoOverloadExpectsCountOfArguments,
 	DiagnosticCode.NoOverloadExpectsCountOfTypeArguments,
 	DiagnosticCode.NoOverloadMatches,
-	DiagnosticCode.Type1IsMissingPropertiesFromType2,
+	DiagnosticCode.Type1IsMissingPropertiesFromType2Variant2,
 	DiagnosticCode.PropertyMissingInType1ButRequiredInType2,
 	DiagnosticCode.TypeHasNoPropertiesInCommonWith,
 	DiagnosticCode.ThisContextOfTypeNotAssignableToMethodOfThisType,

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -28,6 +28,7 @@ const expectErrorDiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.NoOverloadExpectsCountOfArguments,
 	DiagnosticCode.NoOverloadExpectsCountOfTypeArguments,
 	DiagnosticCode.NoOverloadMatches,
+	DiagnosticCode.Type1IsMissingPropertiesFromType2Variant1,
 	DiagnosticCode.Type1IsMissingPropertiesFromType2Variant2,
 	DiagnosticCode.PropertyMissingInType1ButRequiredInType2,
 	DiagnosticCode.TypeHasNoPropertiesInCommonWith,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -58,7 +58,7 @@ export enum DiagnosticCode {
 	IndexSignatureOnlyPermitsReading = 2542,
 	NoOverloadExpectsCountOfArguments = 2575,
 	ThisContextOfTypeNotAssignableToMethodOfThisType = 2684,
-	Type1IsMissingPropertiesFromType2 = 2740,
+	Type1IsMissingPropertiesFromType2Variant2 = 2740,
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 	NoOverloadExpectsCountOfTypeArguments = 2743,
 	NoOverloadMatches = 2769,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -58,6 +58,7 @@ export enum DiagnosticCode {
 	IndexSignatureOnlyPermitsReading = 2542,
 	NoOverloadExpectsCountOfArguments = 2575,
 	ThisContextOfTypeNotAssignableToMethodOfThisType = 2684,
+	Type1IsMissingPropertiesFromType2Variant1 = 2739,
 	Type1IsMissingPropertiesFromType2Variant2 = 2740,
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 	NoOverloadExpectsCountOfTypeArguments = 2743,


### PR DESCRIPTION
Fixes #215.

Please note that error code TS2740 was added in #208, but despite having a different error code, the error messages for TS2739 and TS2740 are otherwise identical. So I've also renamed the enum members to include "variant 1" and "variant 2".
