### PR TITLE
Add `--pass-with-no-tests` option

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -11,13 +11,14 @@ const cli = meow(`
 	  The given directory must contain a package.json and a typings file.
 
 	Info
-	  --help           Display help text
-	  --version        Display version info
+	  --help                Display help text
+	  --version             Display version info
 
 	Options
-	  --typings    -t  Type definition file to test  [Default: "types" property in package.json]
-	  --files      -f  Glob of files to test         [Default: '/path/test-d/**/*.test-d.ts' or '.tsx']
-	  --show-diff      Show type error diffs         [Default: don't show]
+	  --typings    -t       Type definition file to test  [Default: "types" property in package.json]
+	  --files      -f       Glob of files to test         [Default: '/path/test-d/**/*.test-d.ts' or '.tsx']
+	  --show-diff           Show type error diffs         [Default: don't show]
+	  --pass-with-no-tests  Pass when no tests are found  [Default: false]
 
 	Examples
 	  $ tsd /path/to/project
@@ -42,6 +43,10 @@ const cli = meow(`
 		showDiff: {
 			type: 'boolean',
 		},
+		passWithNoTests: {
+			default: false,
+			type: 'boolean',
+		},
 	},
 });
 
@@ -64,9 +69,9 @@ const exit = (message: string, {isError = true}: {isError?: boolean} = {}) => {
 (async () => {
 	try {
 		const cwd = cli.input.length > 0 ? cli.input[0] : process.cwd();
-		const {typings: typingsFile, files: testFiles, showDiff} = cli.flags;
+		const {typings: typingsFile, files: testFiles, showDiff, passWithNoTests} = cli.flags;
 
-		const diagnostics = await tsd({cwd, typingsFile, testFiles});
+		const diagnostics = await tsd({cwd, typingsFile, testFiles, passWithNoTests});
 
 		if (diagnostics.length > 0) {
 			const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error');

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -123,6 +123,32 @@ test('cli typings and files flags', async t => {
 	]);
 });
 
+test('cli passWithNoTests flag', async t => {
+	const runTest = async (arg: '--passWithNoTests') => {
+		const {exitCode} = await execa('../../../cli.js', [arg], {
+			cwd: path.join(__dirname, 'fixtures/no-test')
+		});
+
+		t.is(exitCode, 0);
+	};
+
+	await runTest('--passWithNoTests');
+});
+
+test('cli passWithNoTests flag and files', async t => {
+	const runTest = async (arg: '--pass-with-no-tests') => {
+		const testFile = path.join(__dirname, 'fixtures/does-not-exist.test-d.ts');
+
+		const {exitCode} = await execa('../../../cli.js', [arg, `--files ${testFile}`], {
+			cwd: path.join(__dirname, 'fixtures/no-test')
+		});
+
+		t.is(exitCode, 0);
+	};
+
+	await runTest('--pass-with-no-tests');
+});
+
 test('tsd logs stacktrace on failure', async t => {
 	const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', {
 		cwd: path.join(__dirname, 'fixtures/empty-package-json')


### PR DESCRIPTION
This PR adds a `--pass-with-no-tests` option.

This allows for parity with vitest's [`--passWithNoTests`](https://vitest.dev/guide/cli.html#passwithnotests) and jest's [`--passWithNoTests`](https://jestjs.io/docs/cli#--passwithnotests) options.